### PR TITLE
Спеллинг и прочие ошибки

### DIFF
--- a/docker3.md
+++ b/docker3.md
@@ -15,8 +15,8 @@ Docker myths and receipts. Monkey patch
 Status: Downloaded newer image for php:7
 ```
 
-Теперь у меня есть два чужих класса обычного качества, которые надо связать вместе через инъекцию завиимостей. Самый простой способ инъектить зависимости в чужой код, конечно же, [monkeypatching](https://ru.wikipedia.org/wiki/Monkey_patch)!
-Сначала создаю контейнеры. Помню о [второй сложности программирования](http://martinfowler.com/bliki/TwoHardThings.html) - даю контейнерам вразумительные имена, они будут нужны чтобы контейнеры могли взаимодействовать между собой.
+Теперь у меня есть два чужих класса обычного качества, которые надо связать вместе через инъекцию зависимостей. Самый простой способ инъектить зависимости в чужой код, конечно же, [monkeypatching](https://ru.wikipedia.org/wiki/Monkey_patch)!
+Сначала создаю контейнеры. Помню о [второй сложности программирования](http://martinfowler.com/bliki/TwoHardThings.html) - даю контейнерам вразумительные имена, они будут нужны, чтобы контейнеры могли взаимодействовать между собой.
 ```
 ~$ docker create --name=php7 php:7-fpm
 3d1b737edfcc3f1102fa54c91f9120da4b86d8cbba3092b6f80156c0e31b4d8f
@@ -24,7 +24,7 @@ Status: Downloaded newer image for php:7
 80be81b27e012fd061ff4b682f0b7b8803500bc38a4b9f787f91661603b2d4b7
 ```
 
-Для Nginx расположение конфигов стандартизировано. Где лежат конфиги для PHP можно увидеть в его [Dockerfile]((https://github.com/docker-library/php/blob/f5e091ac3815dce80ca496298e0cb94638844b10/7.0/fpm/Dockerfile)):
+Для Nginx расположение конфигов стандартизировано. Где лежат конфиги для PHP - можно увидеть в его [Dockerfile]((https://github.com/docker-library/php/blob/f5e091ac3815dce80ca496298e0cb94638844b10/7.0/fpm/Dockerfile)):
 ```
 	ENV PHP_INI_DIR /usr/local/etc/php
 	   --with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
@@ -43,7 +43,7 @@ conf.d
 ```
 Мейнтейнеры положили в образ php-fpm.conf, но не удосужились положить дефолтный php.ini. Придется взять его из исходников php.
 
-	$ docker cp $PHP7:/usr/src/php/php.ini-development localetc/php/php.ini
+	$ docker cp "$PHP7:/usr/src/php/php.ini-development" localetc/php/php.ini
 
 Правлю конфиги, как обычно. В какой папке PHP ищет расширения? Узнать придется у самого php.
 Посмотреть конфигурацию php можно, запустив его, например, во временном контейнере.
@@ -59,11 +59,11 @@ opcache.so
 $ echo extension_dir = "/usr/local/lib/php/extensions/no-debug-non-zts-20141001" >>  localetc/php/php.ini
 $ echo zend_extension = opcache.so >> localetc/php/php.ini
 ```
-Пересоздаю контейнер php и монтирую в него папку с конифгами. Путь к монтируемой папке должен быть от корня - служба не знает из какой папки вызывается клент docker.
+Пересоздаю контейнер php и монтирую в него папку с конифгами. Путь к монтируемой папке должен быть от корня - служба не знает, из какой папки вызывается клиент docker.
 ```
 $ docker rm php7
 php7
-$ docker run -v `pwd`/localetc:/usr/local/etc --name=php7 php:7-fpm php -i |grep Configuration
+$ docker run -v "$(pwd)/localetc:/usr/local/etc" --name=php7 php:7-fpm php -i |grep Configuration
 Configuration File (php.ini) Path => /usr/local/etc/php
 Loaded Configuration File => /usr/local/etc/php/php.ini
 ```
@@ -72,17 +72,17 @@ Loaded Configuration File => /usr/local/etc/php/php.ini
 $ docker rm php7
 $ mkdir scripts
 $ echo "<?php echo 'Hello world!'.PHP_EOL;" > scripts/test.php
-$ docker run -v `pwd`/localetc:/usr/local/etc \
-	-v `pwd`/scripts:/scripts \
+$ docker run -v "$(pwd)/localetc:/usr/local/etc" \
+	-v "$(pwd)/scripts:/scripts" \
 	--name=php7 php:7-fpm &
 [29-Aug-2015 15:19:25] NOTICE: fpm is running, pid 1
 [29-Aug-2015 15:19:25] NOTICE: ready to handle connections
 ```
-Пока что для удобства дебага я оставляю вывод из контейнера php-fpm в свою консоль.
+Пока что для удобства отладки я оставляю вывод из контейнера php-fpm в свою консоль.
 Когда будет надо, можно отредактировать конфиги php и fpm в `localetc/` и перезапускать контейнер.
 
-С Nginx все просто и стандартно. В папке `nginx/` надо отредактировать nginx.conf, fastcgi_params по вкусу, и создать конфигурационный файл для своего сайта в `nginx/conf.d/`.
-Основное для связи nginx с php - это указать в имени хоста имя контейнера с php, а директивы root и SCRIPT_FILENAME должны указывать на путь, который php поймет в своем контейнере php7.
+С Nginx всё просто и стандартно. В папке `nginx/` надо отредактировать nginx.conf, fastcgi_params по вкусу, и создать конфигурационный файл для своего сайта в `nginx/conf.d/`.
+Основное для связи nginx с php - это указать в имени хоста имя контейнера с php, а директивы root и SCRIPT_FILENAME должны указывать на путь, который php поймёт в своём контейнере php7.
 
     location ~ \.php$ {
         fastcgi_pass   php7:9000;
@@ -92,10 +92,9 @@ $ docker run -v `pwd`/localetc:/usr/local/etc \
 
 ```
 $ docker rm nginx
-$ docker run -v `pwd`/nginx:/etc/nginx -p 8080:80 --name=nginx nginx &
+$ docker run -v "$(pwd)/nginx:/etc/nginx" -p 8080:80 --name=nginx nginx &
 $ curl 127.0.0.1:8080/test.php
 172.17.0.65 -  29/Aug/2015:15:50:29 +0000 "GET /test.php" 200
 Hello world!
 ```
 Rock'n'Roll!
-


### PR DESCRIPTION
В русском языке нет слов "поймет", "свое".
Использовать обратные кавычки вредно для здоровья.
Квотить результаты работы неявных конструкций надо всегда. За исключением случаев, когда нужно обратное поведение. Это - не тот случай.
